### PR TITLE
fix: ignore aws.dev.* setting overrides in release builds

### DIFF
--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -17,6 +17,7 @@ import { assertHasProps, ClassToInterfaceType, keys } from './utilities/tsUtils'
 import { toRecord } from './utilities/collectionUtils'
 import { once, onceChanged } from './utilities/functionUtils'
 import { ToolkitError } from './errors'
+import { isReleaseVersion } from './vscode/env'
 import { telemetry } from './telemetry/telemetry'
 import globals from './extensionGlobals'
 import toolkitSettings from './settings-toolkit.gen'
@@ -871,6 +872,13 @@ export class DevSettings extends Settings.define('aws.dev', devSettings) {
     }
 
     public override get<K extends AwsDevSetting>(key: K, defaultValue: ResolvedDevSettings[K]) {
+        // In a release build, ignore all `aws.dev.*` overrides unless the developer has
+        // explicitly opted in via `aws.dev.forceDevMode`. These settings are developer-only
+        // and should be inert in the shipped extension regardless of their configuration scope.
+        if (isReleaseVersion() && !this._isSet('forceDevMode')) {
+            return defaultValue
+        }
+
         if (!this._isSet(key)) {
             this.unset(key)
 

--- a/packages/core/src/test/shared/settings.test.ts
+++ b/packages/core/src/test/shared/settings.test.ts
@@ -19,6 +19,7 @@ import { ClassToInterfaceType } from '../../shared/utilities/tsUtils'
 import { Optional } from '../../shared/utilities/typeConstructors'
 import { ToolkitError } from '../../shared/errors'
 import { getTestWindow } from './vscode/window'
+import * as env from '../../shared/vscode/env'
 
 const settingsTarget = vscode.ConfigurationTarget.Workspace
 
@@ -348,6 +349,38 @@ describe('DevSetting', function () {
             await settings.update('aws.dev.forceDevMode', false)
             await settings.update(`aws.dev.${testSetting}`, true).then(() => sut.get(testSetting, false))
             assert.strictEqual(sut.isDevMode(), false)
+        })
+    })
+
+    describe('release build gate', function () {
+        afterEach(function () {
+            sinon.restore()
+        })
+
+        it('ignores dev setting overrides in a release build', async function () {
+            sinon.stub(env, 'isReleaseVersion').returns(true)
+            await settings.update(`aws.dev.${testSetting}`, true)
+            // Even though the setting is set, a release build returns the default.
+            assert.strictEqual(sut.get(testSetting, false), false)
+        })
+
+        it('honors the override in a release build when forceDevMode is set', async function () {
+            sinon.stub(env, 'isReleaseVersion').returns(true)
+            await settings.update('aws.dev.forceDevMode', true)
+            await settings.update(`aws.dev.${testSetting}`, true)
+            assert.strictEqual(sut.get(testSetting, false), true)
+        })
+
+        it('honors the override in a non-release build', async function () {
+            sinon.stub(env, 'isReleaseVersion').returns(false)
+            await settings.update(`aws.dev.${testSetting}`, true)
+            assert.strictEqual(sut.get(testSetting, false), true)
+        })
+
+        it('ignores object overrides (e.g. endpoints) in a release build', async function () {
+            sinon.stub(env, 'isReleaseVersion').returns(true)
+            await settings.update('aws.dev.endpoints', { sso: 'https://override.example' })
+            assert.deepStrictEqual(sut.get('endpoints', {}), {})
         })
     })
 


### PR DESCRIPTION
## Problem
The `aws.dev.*` developer settings are read by `DevSettings.get()` regardless of build type. These settings are intended only for local development, but they are currently honored even in shipped/release builds.

## Change
- Gate `DevSettings.get()` so that `aws.dev.*` overrides are ignored in release builds, unless the developer has explicitly opted in via `aws.dev.forceDevMode`.
- This makes developer-only settings inert in the marketplace build while preserving the existing `forceDevMode` workflow for local development.
- Added unit tests covering release vs. non-release behavior and the `forceDevMode` escape hatch.

## Testing
- Added unit tests in `settings.test.ts` for the release-build gate.
- Existing `DevSetting` tests remain valid (`isReleaseVersion()` is false in the test environment, so the gate is inert there).