### PR TITLE
fix: reset inline chat state when the edited file is deleted

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-93c75b36-50c8-480b-a289-cc1d209bfe5b.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-93c75b36-50c8-480b-a289-cc1d209bfe5b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Inline chat: reset the accept/reject state (code lenses and Enter shortcut) when the file being edited is deleted, so the IDE no longer gets stuck"
+}

--- a/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
+++ b/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
@@ -52,6 +52,28 @@ export class InlineChatController {
         this.computeDiffAndRenderOnEditor = Experiments.instance.get('amazonqLSPInlineChat', false)
             ? this.computeDiffAndRenderOnEditorLSP.bind(this)
             : this.computeDiffAndRenderOnEditorLocal.bind(this)
+
+        // If the file backing an active inline task is deleted, the task can no longer be
+        // accepted or rejected (its editor is gone), which would otherwise leave the
+        // accept/reject code lenses and the Enter-key shortcut context stuck until the IDE
+        // window is reopened. Clean up the inline task when its document is deleted.
+        context.subscriptions.push(
+            vscode.workspace.onDidDeleteFiles(async (event) => {
+                for (const uri of event.files) {
+                    await this.cancelActiveTaskForDeletedDocument(uri)
+                }
+            })
+        )
+    }
+
+    /**
+     * Resets the inline chat state if the currently active task's document was deleted,
+     * so the code lenses and the Enter-key shortcut context do not get stuck.
+     */
+    private async cancelActiveTaskForDeletedDocument(uri: vscode.Uri): Promise<void> {
+        if (this.task?.isActiveState() === true && this.task.document.uri.toString() === uri.toString()) {
+            await this.handleError()
+        }
     }
 
     public async createTask(


### PR DESCRIPTION
## Problem

If a file is deleted while an inline chat suggestion is still pending (e.g. you select the whole file, start inline chat, then delete the file before/while the response is generated), the IDE gets stuck:

- the **Accept/Reject code lenses** stay on top of files, and
- the **Enter key is disabled** (the inline‑chat accept shortcut context stays enabled).

The only workaround is to reopen the IDE window.

## Root cause

`InlineChatController` sets `TaskState.WaitingForDecision` and enables the context key `amazonq.inline.codelensShortcutEnabled` (which binds Enter to "accept"). Accept/Reject only clean up via `reset()` once the user acts — but `acceptAllChanges`/`rejectAllChanges` early‑return when they can't find an editor for the task's document. When the file is deleted, there is no editor, so `reset()` never runs and the lenses + Enter‑shortcut context remain stuck.

## Fix

Register a `vscode.workspace.onDidDeleteFiles` listener in the controller. When the deleted file backs the currently active inline task, run the existing `handleError()` cleanup path, which clears the code lenses (`updateLenses` → empty) and calls `reset()` (which unsets `amazonq.inline.codelensShortcutEnabled` and clears the task). This restores the IDE without needing to reopen the window.

## Testing / verification

- The change is a minimal lifecycle listener that reuses the controller's existing `handleError()` cleanup path.
- Verified via type-check and the repository CI (full compile + unit/integration test matrix).
- Note: I did not add a dedicated unit test for `InlineChatController` — constructing it requires a live language client and streaming dependencies that aren't practical to instantiate in isolation. The fix is intentionally small and delegates to the already‑exercised `handleError()` path. Reviewer visual confirmation of the exact repro (delete file mid‑generation) is welcome.
