### PR TITLE
fix: repoint CODEOWNERS and workflow org guards to Amazon-Q-Developer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
-* @aws/aws-ides-team
-packages/core/src/codewhisperer/ @aws/codewhisperer-team
-packages/core/src/amazonqFeatureDev/ @aws/earlybird
-packages/core/src/awsService/accessanalyzer/ @aws/access-analyzer
-packages/core/src/awsService/cloudformation/ @aws/cfn-dev-productivity
+* @Amazon-Q-Developer/sync-team-dae-production-eng-team

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -150,7 +150,7 @@ jobs:
               env:
                   # Unset NODE_OPTIONS because of https://github.com/codecov/uploader/issues/475
                   NODE_OPTIONS: ''
-              if: ${{ github.repository == 'aws/amazon-q-vscode' && github.event_name == 'pull_request' && github.base_ref == 'main' }}
+              if: ${{ github.repository == 'Amazon-Q-Developer/amazon-q-vscode' && github.event_name == 'pull_request' && github.base_ref == 'main' }}
               uses: codecov/codecov-action@v5
               with:
                   flags: linux-${{ matrix.package }}-unittests
@@ -188,7 +188,7 @@ jobs:
               env:
                   # Unset NODE_OPTIONS because of https://github.com/codecov/uploader/issues/475
                   NODE_OPTIONS: ''
-              if: ${{ github.repository == 'aws/amazon-q-vscode' && github.event_name == 'pull_request' && github.base_ref == 'main' }}
+              if: ${{ github.repository == 'Amazon-Q-Developer/amazon-q-vscode' && github.event_name == 'pull_request' && github.base_ref == 'main' }}
               uses: codecov/codecov-action@v5
               with:
                   flags: macos-${{ matrix.package }}-unittests
@@ -259,7 +259,7 @@ jobs:
             - name: Code coverage for ${{ matrix.package }}
               env:
                   NODE_OPTIONS: ''
-              if: ${{ github.repository == 'aws/amazon-q-vscode' && github.event_name == 'pull_request' && github.base_ref == 'main' }}
+              if: ${{ github.repository == 'Amazon-Q-Developer/amazon-q-vscode' && github.event_name == 'pull_request' && github.base_ref == 'main' }}
               uses: codecov/codecov-action@v5
               with:
                   flags: linux-${{ matrix.package }}-e2e
@@ -344,7 +344,7 @@ jobs:
               env:
                   # Unset NODE_OPTIONS because of https://github.com/codecov/uploader/issues/475
                   NODE_OPTIONS: ''
-              if: ${{ github.repository == 'aws/amazon-q-vscode' && github.event_name == 'pull_request' && github.base_ref == 'main' }}
+              if: ${{ github.repository == 'Amazon-Q-Developer/amazon-q-vscode' && github.event_name == 'pull_request' && github.base_ref == 'main' }}
               uses: codecov/codecov-action@v5
               with:
                   flags: windows-${{ matrix.package }}-unittests

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
     notify:
-        if: github.repository == 'aws/amazon-q-vscode'
+        if: github.repository == 'Amazon-Q-Developer/amazon-q-vscode'
         runs-on: ubuntu-latest
         permissions:
             pull-requests: write


### PR DESCRIPTION
## Problem

`amazon-q-vscode` moved from the `aws` org to `Amazon-Q-Developer` ([P484890134](https://t.corp.amazon.com/P484890134)). Two things broke as a result:

1. **CODEOWNERS** references `@aws/*` teams that don't exist in the new org — every entry is an "Unknown owner", so the required code-owner review can't be satisfied.
2. Two workflows gate steps on `github.repository == 'aws/amazon-q-vscode'`, which now evaluates false, silently skipping them:
   - `node.js.yml` — Codecov coverage upload on PRs (x4)
   - `notification.yml` — the PR-notification job

## Solution

- **CODEOWNERS:** collapse to `@Amazon-Q-Developer/sync-team-dae-production-eng-team` (the synced eng team), matching what was done for `language-servers`. The granular per-directory teams (`codewhisperer-team`, `earlybird`, `access-analyzer`, `cfn-dev-productivity`) have no equivalent in the new org yet; they can be reintroduced if/when matching teams are created.
- **Workflows:** repoint the org guards to `Amazon-Q-Developer/amazon-q-vscode`.

## Testing

Mechanical string changes. CODEOWNERS resolution can be confirmed via `repos/.../codeowners/errors` once merged; the workflow guards take effect on the next PR/push.

## Out of scope

Cosmetic `github.com/aws/...` doc/link references (READMEs, CONTRIBUTING, package.json `repository.url`) — they redirect and don't affect functionality.
