### PR TITLE
build(amazonq): bump version to 2.7.0-SNAPSHOT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38849,7 +38849,7 @@
         },
         "packages/amazonq": {
             "name": "amazon-q-vscode",
-            "version": "2.6.0-SNAPSHOT",
+            "version": "2.7.0-SNAPSHOT",
             "license": "Apache-2.0",
             "dependencies": {
                 "aws-core-vscode": "file:../core/"

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -2,7 +2,7 @@
     "name": "amazon-q-vscode",
     "displayName": "Amazon Q",
     "description": "The most capable generative AI–powered assistant for software development.",
-    "version": "2.6.0-SNAPSHOT",
+    "version": "2.7.0-SNAPSHOT",
     "extensionKind": [
         "workspace"
     ],


### PR DESCRIPTION
The post-2.6.0 snapshot bump (02872a53) was regressed by the rc-20260821 merge-back, leaving main and this RC at 2.6.0-SNAPSHOT. The RC build therefore produced amazon-q-vscode-2.6.0-g1e40eb2.vsix, which cannot ship (2.6.0 is already on the Marketplace, which rejects reused versions).

This restores 2.7.0-SNAPSHOT in packages/amazonq/package.json and the matching package-lock.json entry so release.yml builds 2.7.0. Same fix pattern as amazon-q-jetbrains PR #127.

After merge: re-run release.yml from release/rc-20260902. Main inherits the fix via the post-release RC merge-back.