### PR TITLE
fix: stop duplicating surrounding code in inline chat diffs

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-d69304db-debc-4eec-902b-b2837faec78a.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-d69304db-debc-4eec-902b-b2837faec78a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q: Inline chat no longer duplicates surrounding code when the response repeats the code around the cursor or selection (for example when invoked on an empty line inside a function). Only the new lines are shown as an insertion, and the suggested code is indented to match the existing code."
+}

--- a/packages/amazonq/src/inlineChat/output/computeDiff.ts
+++ b/packages/amazonq/src/inlineChat/output/computeDiff.ts
@@ -10,12 +10,19 @@ export function computeDiff(response: string, inlineTask: InlineTask, isPartialD
     if (!response) {
         return
     }
+    if (!isPartialDiff) {
+        response = anchorResponseToDocument(response, inlineTask)
+    }
     const selectedRange = inlineTask.selectedRange
     const partialSelectedText = inlineTask.partialSelectedText ?? ''
     const selectedText = isPartialDiff ? partialSelectedText : inlineTask.selectedText
 
+    // With no selected code to align with (e.g. cursor on an empty line), keep the indentation the
+    // response came with instead of re-basing its first line on the (empty) selection.
     const normalizedResponse =
-        getLeadingWhitespace(selectedText) + response.trim() + getTrailingWhitespace(selectedText)
+        selectedText.trim() === ''
+            ? trimBlankLines(response.split('\n')).join('\n')
+            : getLeadingWhitespace(selectedText) + response.trim() + getTrailingWhitespace(selectedText)
 
     const diffs = diffLines(selectedText, normalizedResponse, {
         stripTrailingCr: true,
@@ -112,4 +119,124 @@ function getLeadingWhitespace(str: string): string {
 function getTrailingWhitespace(str: string): string {
     const match = str.match(/\s*$/)
     return match ? match[0] : ''
+}
+
+/**
+ * Widens the task selection to cover document lines that the response repeats verbatim
+ * (ignoring indentation) immediately above and below the current selection.
+ *
+ * The model is given the code surrounding the selection as context and frequently answers with
+ * the whole enclosing block, e.g. when inline chat is invoked on an empty line inside a function.
+ * Diffing that response against the original (possibly empty) selection would insert the
+ * surrounding lines a second time. By extending the selection to the echoed lines, they diff as
+ * unchanged and only the genuinely new code is shown as an insertion.
+ *
+ * When lines are anchored, the response is re-indented so that its anchored lines line up with
+ * the matching document lines.
+ *
+ * @returns the response, re-indented if anchoring occurred; otherwise the original response.
+ */
+export function anchorResponseToDocument(response: string, inlineTask: InlineTask): string {
+    const document = inlineTask.document
+    const responseLines = trimBlankLines(response.split('\n'))
+    if (responseLines.length === 0) {
+        return response
+    }
+
+    const startLine = inlineTask.selectedRange.start.line
+    const endLine = inlineTask.selectedRange.end.line
+
+    const prefixLength = findPrefixOverlap(document, startLine, responseLines)
+    const suffixLength = findSuffixOverlap(document, endLine, responseLines, responseLines.length - prefixLength)
+    if (prefixLength === 0 && suffixLength === 0) {
+        return response
+    }
+
+    const anchoredStart = startLine - prefixLength
+    const anchoredEnd = endLine + suffixLength
+    inlineTask.selectedRange = new vscode.Range(
+        document.lineAt(anchoredStart).range.start,
+        document.lineAt(anchoredEnd).range.end
+    )
+    inlineTask.selectedText = document.getText(inlineTask.selectedRange)
+
+    // Re-base the indentation of the response on the first anchored document line.
+    const [documentLine, responseLine] =
+        prefixLength > 0
+            ? [document.lineAt(anchoredStart).text, responseLines[0]]
+            : [document.lineAt(endLine + 1).text, responseLines[responseLines.length - suffixLength]]
+    return reindent(responseLines, getLeadingWhitespace(responseLine), getLeadingWhitespace(documentLine)).join('\n')
+}
+
+/**
+ * Number of response lines (from the start) that match the document lines directly above `line`.
+ * Prefers the longest match.
+ */
+function findPrefixOverlap(document: vscode.TextDocument, line: number, responseLines: string[]): number {
+    for (let length = Math.min(responseLines.length, line); length > 0; length--) {
+        const documentLines = getDocumentLines(document, line - length, length)
+        if (linesMatch(documentLines, responseLines.slice(0, length))) {
+            return length
+        }
+    }
+    return 0
+}
+
+/**
+ * Number of response lines (from the end) that match the document lines directly below `line`.
+ * Prefers the longest match.
+ */
+function findSuffixOverlap(
+    document: vscode.TextDocument,
+    line: number,
+    responseLines: string[],
+    maxLength: number
+): number {
+    const linesBelow = document.lineCount - 1 - line
+    for (let length = Math.min(maxLength, linesBelow); length > 0; length--) {
+        const documentLines = getDocumentLines(document, line + 1, length)
+        if (linesMatch(documentLines, responseLines.slice(responseLines.length - length))) {
+            return length
+        }
+    }
+    return 0
+}
+
+function getDocumentLines(document: vscode.TextDocument, start: number, count: number): string[] {
+    const lines: string[] = []
+    for (let i = start; i < start + count; i++) {
+        lines.push(document.lineAt(i).text)
+    }
+    return lines
+}
+
+function linesMatch(documentLines: string[], responseLines: string[]): boolean {
+    return (
+        documentLines.length === responseLines.length &&
+        documentLines.every((line, i) => line.trim() === responseLines[i].trim())
+    )
+}
+
+function trimBlankLines(lines: string[]): string[] {
+    let start = 0
+    let end = lines.length
+    while (start < end && lines[start].trim() === '') {
+        start++
+    }
+    while (end > start && lines[end - 1].trim() === '') {
+        end--
+    }
+    return lines.slice(start, end)
+}
+
+function reindent(lines: string[], fromIndent: string, toIndent: string): string[] {
+    if (fromIndent === toIndent) {
+        return lines
+    }
+    return lines.map((line) => {
+        if (line.trim() === '') {
+            return line
+        }
+        return line.startsWith(fromIndent) ? toIndent + line.slice(fromIndent.length) : line
+    })
 }

--- a/packages/amazonq/test/unit/inlineChat/computeDiff.test.ts
+++ b/packages/amazonq/test/unit/inlineChat/computeDiff.test.ts
@@ -1,0 +1,172 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { createMockDocument } from 'aws-core-vscode/test'
+import { InlineTask, TextDiff } from '../../../src/inlineChat/controller/inlineTask'
+import { anchorResponseToDocument, computeDiff } from '../../../src/inlineChat/output/computeDiff'
+
+function createTask(content: string, selection: vscode.Selection): InlineTask {
+    return new InlineTask('query', createMockDocument(content), selection)
+}
+
+function cursorAt(line: number, character = 0): vscode.Selection {
+    return new vscode.Selection(line, character, line, character)
+}
+
+function insertions(diff: TextDiff[] | undefined) {
+    return (diff ?? []).filter((d): d is Extract<TextDiff, { type: 'insertion' }> => d.type === 'insertion')
+}
+
+function deletions(diff: TextDiff[] | undefined) {
+    return (diff ?? []).filter((d): d is Extract<TextDiff, { type: 'deletion' }> => d.type === 'deletion')
+}
+
+describe('inlineChat computeDiff', function () {
+    const source = [
+        'class Foo:',
+        '    def bar(self):',
+        '        x = 1',
+        '',
+        '        return x',
+        '',
+        'def baz():',
+        '    pass',
+        '',
+    ].join('\n')
+
+    describe('anchorResponseToDocument', function () {
+        it('widens an empty selection to the surrounding lines echoed by the response', function () {
+            const task = createTask(source, cursorAt(3))
+            const response = ['    def bar(self):', '        x = 1', '        y = 2', '        return x'].join('\n')
+
+            const anchored = anchorResponseToDocument(response, task)
+
+            assert.strictEqual(task.selectedRange.start.line, 1)
+            assert.strictEqual(task.selectedRange.end.line, 4)
+            assert.strictEqual(
+                task.selectedText,
+                ['    def bar(self):', '        x = 1', '', '        return x'].join('\n')
+            )
+            assert.strictEqual(anchored, response)
+        })
+
+        it('re-indents the response to line up with the anchored document lines', function () {
+            const task = createTask(source, cursorAt(3))
+            const response = ['def bar(self):', '    x = 1', '    y = 2', '', '    return x'].join('\n')
+
+            const anchored = anchorResponseToDocument(response, task)
+
+            assert.strictEqual(task.selectedRange.start.line, 1)
+            assert.strictEqual(task.selectedRange.end.line, 4)
+            assert.strictEqual(
+                anchored,
+                ['    def bar(self):', '        x = 1', '        y = 2', '', '        return x'].join('\n')
+            )
+        })
+
+        it('anchors on only one side when the response echoes only lines above the selection', function () {
+            const task = createTask(source, cursorAt(3))
+            const response = ['        x = 1', '        y = 2'].join('\n')
+
+            anchorResponseToDocument(response, task)
+
+            assert.strictEqual(task.selectedRange.start.line, 2)
+            assert.strictEqual(task.selectedRange.end.line, 3)
+        })
+
+        it('anchors on only one side when the response echoes only lines below the selection', function () {
+            const task = createTask(source, cursorAt(3))
+            const response = ['        y = 2', '        return x'].join('\n')
+
+            anchorResponseToDocument(response, task)
+
+            assert.strictEqual(task.selectedRange.start.line, 3)
+            assert.strictEqual(task.selectedRange.end.line, 4)
+        })
+
+        it('leaves the selection untouched when the response does not repeat surrounding code', function () {
+            const task = createTask(source, cursorAt(3))
+            const response = '        y = 2'
+
+            const anchored = anchorResponseToDocument(response, task)
+
+            assert.strictEqual(task.selectedRange.start.line, 3)
+            assert.strictEqual(task.selectedRange.end.line, 3)
+            assert.strictEqual(anchored, response)
+        })
+
+        it('ignores leading and trailing blank lines in the response when anchoring', function () {
+            const task = createTask(source, cursorAt(3))
+            const response = ['', '    def bar(self):', '        x = 1', '        y = 2', '        return x', ''].join(
+                '\n'
+            )
+
+            anchorResponseToDocument(response, task)
+
+            assert.strictEqual(task.selectedRange.start.line, 1)
+            assert.strictEqual(task.selectedRange.end.line, 4)
+        })
+
+        it('widens a non-empty selection when the response repeats the enclosing block', function () {
+            const task = createTask(source, new vscode.Selection(2, 0, 2, 13))
+            const response = ['    def bar(self):', '        x = 10', '', '        return x'].join('\n')
+
+            anchorResponseToDocument(response, task)
+
+            assert.strictEqual(task.selectedRange.start.line, 1)
+            assert.strictEqual(task.selectedRange.end.line, 4)
+        })
+    })
+
+    describe('computeDiff', function () {
+        it('only inserts the new code when the response echoes the enclosing method', function () {
+            const task = createTask(source, cursorAt(3))
+            const response = ['    def bar(self):', '        x = 1', '        y = 2', '        return x'].join('\n')
+
+            const diff = computeDiff(response, task, false)
+
+            const added = insertions(diff)
+            assert.strictEqual(added.length, 1)
+            assert.strictEqual(added[0].replacementText, '        y = 2\n')
+            assert.strictEqual(added[0].range.start.line, 4)
+            assert.strictEqual(deletions(diff).length, 0)
+        })
+
+        it('inserts the response at the cursor when nothing is echoed', function () {
+            const task = createTask(source, cursorAt(3))
+
+            const diff = computeDiff('        y = 2', task, false)
+
+            const added = insertions(diff)
+            assert.strictEqual(added.length, 1)
+            assert.strictEqual(added[0].replacementText, '        y = 2')
+            assert.strictEqual(added[0].range.start.line, 3)
+        })
+
+        it('keeps the indentation of every response line when the selection is empty', function () {
+            const task = createTask(source, cursorAt(3))
+            const response = ['        if x:', '            x += 1'].join('\n')
+
+            const diff = computeDiff(response, task, false)
+
+            const added = insertions(diff)
+            assert.strictEqual(added.length, 1)
+            assert.strictEqual(added[0].replacementText, '        if x:\n            x += 1')
+        })
+
+        it('does not anchor partial responses', function () {
+            const task = createTask(source, cursorAt(3))
+            task.partialSelectedText = ''
+            const response = ['    def bar(self):', '        x = 1'].join('\n')
+
+            computeDiff(response, task, true)
+
+            assert.strictEqual(task.selectedRange.start.line, 3)
+            assert.strictEqual(task.selectedRange.end.line, 3)
+        })
+    })
+})


### PR DESCRIPTION
## Problem

When inline chat is invoked with the cursor on a blank line (no selection) inside a function, the returned diff re-inserts the entire enclosing method with the new code inside it. Accepting the diff duplicates the lines that already exist above and below the cursor, and the inserted block is mis-indented compared to the surrounding code.

Root cause: `InlineTask` treats the cursor's (empty) line as the selected text, while the model is given the surrounding code as context and typically answers with the whole enclosing block. `computeDiff` then diffs the full response against an empty string, so every line—including code that already exists—becomes an insertion. The first line's indentation is also re-based on the empty selection, so it lands at column 0 while later lines keep the model's indentation.

## Solution

Before diffing a complete response, anchor it against the document:

- Find the longest run of response lines (from the start) that matches the document lines directly above the selection, and the longest run (from the end) that matches the lines directly below it. Matching ignores indentation.
- Widen the task's selection to cover those lines so they diff as unchanged; only the genuinely new lines are shown as an insertion.
- Re-indent the response so its anchored lines line up with the matching document lines.
- If nothing is echoed and the selection is blank, keep the response's own indentation for every line instead of stripping the first line's indent.

Partial (streaming) diffs are left as-is and are corrected when the final response is applied. Behavior for non-empty selections whose response does not repeat surrounding code is unchanged.

Adds unit tests for `anchorResponseToDocument` and `computeDiff` covering: echoing the enclosing method with an empty selection, re-indentation, one-sided overlap, no overlap, blank-line trimming, non-empty selections, partial responses, and a regression check for a plain selection rewrite.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/amazon-q-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
